### PR TITLE
fix setTimeout in notifyCadenceCSP

### DIFF
--- a/example/simulator.js
+++ b/example/simulator.js
@@ -101,7 +101,7 @@ var notifyCadenceCSP = function() {
   stroke_count += 1;
   if( cadence <= 0) {
     cadence = 0;
-    setTimeout(notifyCadence, notificationInterval);
+    setTimeout(notifyCadenceCSP, notificationInterval);
     return;
   }
   try {


### PR DESCRIPTION
There is a reference to a non-existent function `notifyCadence` within `notifyCadenceCSP`.
Looks like it was introduced during some refactoring performed earlier.